### PR TITLE
fix: derive Trolley-Source header from package.json version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@5.0.3
+  codecov: codecov/codecov@5.4.3
 
 executors:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,10 @@ jobs:
           command: npm run test:CI
       - run:
           name: Install Codecov CLI
-          command: python3 -m pip install --user codecov-cli
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y python3-pip
+            python3 -m pip install --user codecov-cli
       - codecov/upload:
           token: CODECOV_TOKEN
           slug: trolley/javascript-sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           token: CODECOV_TOKEN
           slug: trolley/javascript-sdk
           files: coverage/lcov.info
-          skip_validation: true
+          use_pypi: true
           when: always
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           token: CODECOV_TOKEN
           slug: trolley/javascript-sdk
           files: coverage/lcov.info
+          skip_validation: true
           when: always
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,14 @@ jobs:
       - run:
           name: Run unit tests with coverage
           command: npm run test:CI
+      - run:
+          name: Install Codecov CLI
+          command: python3 -m pip install --user codecov-cli
       - codecov/upload:
           token: CODECOV_TOKEN
           slug: trolley/javascript-sdk
           files: coverage/lcov.info
-          use_pypi: true
+          binary: /home/circleci/.local/bin/codecov
           when: always
 
   build:

--- a/lib/Client.ts
+++ b/lib/Client.ts
@@ -10,7 +10,7 @@ import ValidationError = Errors.ValidationError;
  * @hidden
  */
 
-const CURRENT_CLIENT_VERSION = "1.1.0";
+const CURRENT_CLIENT_VERSION = require("../package.json").version;
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",
   "Trolley-Source": `javascript-sdk_${CURRENT_CLIENT_VERSION}`,

--- a/test/unit/releasePrepSpec.ts
+++ b/test/unit/releasePrepSpec.ts
@@ -1,10 +1,14 @@
 import { Batch, Balance, Configuration, Gateway, OfflinePayment, Payment, Recipient, RecipientAccount } from "../../lib";
 import { BalancesGateway } from "../../lib/BalancesGateway";
+import { Client } from "../../lib/Client";
 import { PaymentGateway } from "../../lib/PaymentGateway";
 import { VerificationGateway } from "../../lib/VerificationGateway";
 
 import * as assert from "assert";
+import * as nock from "nock";
 import * as sinon from "sinon";
+
+const packageInfo = require("../../package.json");
 
 describe("Release prep endpoint coverage", () => {
   let sandbox: sinon.SinonSandbox;
@@ -30,6 +34,21 @@ describe("Release prep endpoint coverage", () => {
 
   afterEach(() => {
     sandbox.restore();
+    nock.cleanAll();
+  });
+
+  it("uses the package version in the source header", async () => {
+    const sourceHeader = `javascript-sdk_${packageInfo.version}`;
+    const request = nock("https://api.trolley.com")
+      .matchHeader("Trolley-Source", sourceHeader)
+      .get("/v1/balances")
+      .reply(200, { ok: true });
+
+    const apiClient = new Client(new Configuration({ key: "access", secret: "secret" }));
+
+    await apiClient.get("/v1/balances");
+
+    assert.ok(request.isDone());
   });
 
   it("uses documented balance endpoints", async () => {


### PR DESCRIPTION
## Summary

The SDK was sending a hardcoded `Trolley-Source` header (`javascript-sdk_1.1.0`) even though `package.json` is at `1.2.0`. This PR reads the version from `package.json` at runtime so the header stays in sync with releases.

## Changes

### SDK
- **`lib/Client.ts`**: Replace hardcoded `CURRENT_CLIENT_VERSION = "1.1.0"` with `require("../package.json").version`
- **`Trolley-Source` header** is now built as `javascript-sdk_${packageVersion}` automatically on each release

### Tests
- Add unit test in `test/unit/releasePrepSpec.ts` that asserts outgoing requests include the correct `Trolley-Source` header matching `package.json`

### CI (Codecov)
- Bump Codecov orb from `5.0.3` → `5.4.3`
- Install Codecov CLI via PyPI before upload and point the orb at the installed binary